### PR TITLE
feat: Add Recommended Rest Time to pacing plan

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
           <th>Section Time</th>
           <th>Avg. Pace (min/km)</th>
           <th>Arrival Time</th>
+          <th>Recommended Rest</th>
           <th>Official Deadline</th>
         </tr>
       </thead>

--- a/main.js
+++ b/main.js
@@ -170,6 +170,12 @@ function generatePacingPlan() {
         return;
     }
 
+    const restTimes = {
+      'Kalmakaltio': goalTimeMinutes * 0.005,
+      'Hetta': goalTimeMinutes * 0.025,
+      'Pallas': goalTimeMinutes * 0.025
+    };
+
     // 2. Analyze terrain and effort for each section
     const sections = [];
     for (let i = 0; i < cutOffs.length - 1; i++) {
@@ -233,12 +239,16 @@ function generatePacingPlan() {
         const avgPace = section.allocatedTime / section.calculatedDistance;
 
         const row = document.createElement("tr");
+        const sectionEndName = section.name.split(' to ')[1];
+        const recommendedRest = restTimes[sectionEndName] ? minutesToTimeStr(restTimes[sectionEndName]) : '—';
+
         row.innerHTML = `
             <td>${section.name}</td>
             <td>${section.officialDistance.toFixed(2)}</td>
             <td>${minutesToTimeStr(section.allocatedTime)}</td>
             <td>${avgPace.toFixed(2)}</td>
             <td>${minutesToTimeStr(arrivalTime)}</td>
+            <td>${recommendedRest}</td>
             <td>${minutesToTimeStr(section.officialDeadline)}</td>
         `;
         tableBody.appendChild(row);


### PR DESCRIPTION
This commit introduces a "Recommended Rest Time" column to the pacing plan table.

- Adds a new column header to `index.html`.
- Calculates recommended rest times for Kalmakaltio (0.5%), Hetta (2.5%), and Pallas (2.5%) based on your goal finish time in `main.js`.
- Displays the calculated rest time for the corresponding aid station sections.
- The rest time is purely informational and does not affect the existing pacing or arrival time calculations.